### PR TITLE
修复错误的¥字符导致的Parser转换失败

### DIFF
--- a/spring-dataops/spring-dataops-parser/src/main/java/com/xcs/spring/ParserDemo.java
+++ b/spring-dataops/spring-dataops-parser/src/main/java/com/xcs/spring/ParserDemo.java
@@ -23,7 +23,7 @@ public class ParserDemo {
         // 改变区域设置为中国
         LocaleContextHolder.setLocale(Locale.CHINA);
         // 将人民币格式的字符串转换为数值类型
-        Number formattedAmountForCHINA = conversionService.convert("￥1,234.56", Number.class);
+        Number formattedAmountForCHINA = conversionService.convert("¥1,234.56", Number.class);
         System.out.println("Parsed Currency (CHINA): " + formattedAmountForCHINA);
     }
 }


### PR DESCRIPTION
原代码demo中的人民币字符无法正确被识别导致货币转换数字出现错误，改用正确的人民币字符后可以正常运行通过。